### PR TITLE
Query param order shouldn't matter to URL equality

### DIFF
--- a/spec/lib/fake_web_matcher/matchers_spec.rb
+++ b/spec/lib/fake_web_matcher/matchers_spec.rb
@@ -32,4 +32,11 @@ describe FakeWebMatcher::Matchers do
     
     FakeWeb.should_not have_requested(:get, 'http://example.com')
   end
+
+  it "should not care about the order of the query parameters" do
+    FakeWeb.register_uri(:get, URI.parse('http://example.com/page?foo=bar&baz=qux'), :body => 'foo')
+    open('http://example.com/page?baz=qux&foo=bar')
+
+    FakeWeb.should have_requested(:get, 'http://example.com/page?foo=bar&baz=qux')
+  end
 end


### PR DESCRIPTION
These two URLs should be equivalent (and FakeWeb treats them as such):
- http://example.com/page?foo=bar&baz=qux
- http://example.com/page?baz=qux&foo=bar

This patch fixes this in fakeweb-matcher by adding a normalize! method to the URI::HTTP class that sorts the query params and then calls the upstream URI::Generic#normalize!.
