### PR TITLE
Fix deprecation warnings

### DIFF
--- a/VERSION.yml
+++ b/VERSION.yml
@@ -1,4 +1,4 @@
 ---
 :major: 1
 :minor: 2
-:patch: 3
+:patch: 4

--- a/lib/fake_web_matcher/request_matcher.rb
+++ b/lib/fake_web_matcher/request_matcher.rb
@@ -66,6 +66,14 @@ module FakeWebMatcher
       regex?(@url) ? regex_negative_failure_message : url_negative_failure_message
     end
 
+    # Failure message if the URI should not have been requested.
+    #
+    # @return [String] failure message
+    #
+    def failure_message_when_negated
+      regex?(@url) ? regex_negative_failure_message : url_negative_failure_message
+    end
+
     private
 
     def regex_negative_failure_message

--- a/lib/fake_web_matcher/request_matcher.rb
+++ b/lib/fake_web_matcher/request_matcher.rb
@@ -58,7 +58,7 @@ module FakeWebMatcher
       regex?(@url) ? regex_failure_message : url_failure_message
     end
 
-    # Failure message if the URI should not have been requested.
+    # Failure message if the URI should not have been requested. (Deprecated)
     #
     # @return [String] failure message
     #


### PR DESCRIPTION
I tried adding this gem to support a slightly older project, and I ran into the following deprecation warning:

```
Deprecation Warnings:

--------------------------------------------------------------------------------
FakeWebMatcher::RequestMatcher implements a legacy RSpec matcher
protocol. For the current protocol you should expose the failure messages
via the `failure_message` and `failure_message_when_negated` methods.
--------------------------------------------------------------------------------

If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.
```

This PR adds the necessary method to make RSpec 3.5 and up happy.